### PR TITLE
fix(dockerfile): Pin golang docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.14.3-alpine
 
 COPY cmd /usr/local/bin
 COPY entrypoint /usr/local/bin


### PR DESCRIPTION
Something happened in the `golang:alpine tag` to break this and changing the FROM image to  `golang:1.14.3-alpine` seems to fix it.